### PR TITLE
chore: memory stores used by test are now initialized with pointer values

### DIFF
--- a/internal/auth/app/command/create_first_account_test.go
+++ b/internal/auth/app/command/create_first_account_test.go
@@ -17,13 +17,14 @@ func Test_CreateFirstAccount(t *testing.T) {
 	hasher := infra.NewBCryptHasher()
 	keygen := infra.NewKeyGenerator()
 
-	createFirstAccount := func(existingUsers ...domain.User) (func(context.Context, command.CreateFirstAccountCommand) error, memory.UsersStore) {
+	createFirstAccount := func(existingUsers ...*domain.User) (func(context.Context, command.CreateFirstAccountCommand) error, memory.UsersStore) {
 		store := memory.NewUsersStore(existingUsers...)
 		return command.CreateFirstAccount(store, store, hasher, keygen), store
 	}
 
 	t.Run("should do nothing if a user already exists", func(t *testing.T) {
-		uc, store := createFirstAccount(domain.NewUser("existing@example.com", "password", "apikey"))
+		usr := domain.NewUser("existing@example.com", "password", "apikey")
+		uc, store := createFirstAccount(&usr)
 
 		err := uc(ctx, command.CreateFirstAccountCommand{})
 

--- a/internal/auth/app/command/login_test.go
+++ b/internal/auth/app/command/login_test.go
@@ -16,7 +16,7 @@ import (
 func Test_Login(t *testing.T) {
 	hasher := infra.NewBCryptHasher()
 	password, _ := hasher.Hash("password") // Sample password hash for the string "password" for tests
-	login := func(existingUsers ...domain.User) func(context.Context, command.LoginCommand) (string, error) {
+	login := func(existingUsers ...*domain.User) func(context.Context, command.LoginCommand) (string, error) {
 		store := memory.NewUsersStore(existingUsers...)
 		return command.Login(store, hasher)
 	}
@@ -42,7 +42,8 @@ func Test_Login(t *testing.T) {
 	})
 
 	t.Run("should complains if password does not match", func(t *testing.T) {
-		uc := login(domain.NewUser("existing@example.com", password, "apikey"))
+		usr := domain.NewUser("existing@example.com", password, "apikey")
+		uc := login(&usr)
 		_, err := uc(context.Background(), command.LoginCommand{
 			Email:    "existing@example.com",
 			Password: "nobodycares",
@@ -56,7 +57,7 @@ func Test_Login(t *testing.T) {
 
 	t.Run("should returns a valid user id if it succeeds", func(t *testing.T) {
 		existingUser := domain.NewUser("existing@example.com", password, "apikey")
-		uc := login(existingUser)
+		uc := login(&existingUser)
 		uid, err := uc(context.Background(), command.LoginCommand{
 			Email:    "existing@example.com",
 			Password: "password",

--- a/internal/auth/infra/memory/users.go
+++ b/internal/auth/infra/memory/users.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/YuukanOO/seelf/internal/auth/domain"
 	"github.com/YuukanOO/seelf/pkg/apperr"
-	"github.com/YuukanOO/seelf/pkg/collections"
 	"github.com/YuukanOO/seelf/pkg/event"
 )
 
@@ -28,11 +27,10 @@ type (
 	}
 )
 
-func NewUsersStore(existingUsers ...domain.User) UsersStore {
+func NewUsersStore(existingUsers ...*domain.User) UsersStore {
 	s := &usersStore{}
-	ctx := context.Background()
 
-	s.Write(ctx, collections.ToPointers(existingUsers)...)
+	s.Write(context.Background(), existingUsers...)
 
 	return s
 }
@@ -131,7 +129,7 @@ func (s *usersStore) Write(ctx context.Context, users ...*domain.User) error {
 			default:
 				for _, u := range s.users {
 					if u.id == user.ID() {
-						u.value = user
+						*u.value = *user
 						break
 					}
 				}

--- a/internal/deployment/app/command/cleanup_app_test.go
+++ b/internal/deployment/app/command/cleanup_app_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 type initialData struct {
-	existingApps        []domain.App
-	existingDeployments []domain.Deployment
+	existingApps        []*domain.App
+	existingDeployments []*domain.Deployment
 }
 
 func Test_CleanupApp(t *testing.T) {
@@ -51,7 +51,7 @@ func Test_CleanupApp(t *testing.T) {
 	t.Run("should fail if the application cleanup as not been requested", func(t *testing.T) {
 		app := domain.NewApp("my-app", "uid")
 		uc := cleanup(initialData{
-			existingApps: []domain.App{app},
+			existingApps: []*domain.App{&app},
 		})
 
 		err := uc(ctx, command.CleanupAppCommand{
@@ -67,8 +67,8 @@ func Test_CleanupApp(t *testing.T) {
 		app.RequestCleanup("uid")
 
 		uc := cleanup(initialData{
-			existingApps:        []domain.App{app},
-			existingDeployments: []domain.Deployment{depl},
+			existingApps:        []*domain.App{&app},
+			existingDeployments: []*domain.Deployment{&depl},
 		})
 
 		err := uc(ctx, command.CleanupAppCommand{
@@ -83,7 +83,7 @@ func Test_CleanupApp(t *testing.T) {
 		app.RequestCleanup("uid")
 
 		uc := cleanup(initialData{
-			existingApps: []domain.App{app},
+			existingApps: []*domain.App{&app},
 		})
 
 		err := uc(ctx, command.CleanupAppCommand{
@@ -91,5 +91,6 @@ func Test_CleanupApp(t *testing.T) {
 		})
 
 		testutil.IsNil(t, err)
+		testutil.EventIs[domain.AppDeleted](t, &app, 2)
 	})
 }

--- a/internal/deployment/app/command/create_app_test.go
+++ b/internal/deployment/app/command/create_app_test.go
@@ -15,7 +15,7 @@ import (
 
 func Test_CreateApp(t *testing.T) {
 	ctx := auth.WithUserID(context.Background(), "some-uid")
-	create := func(existingApps ...domain.App) func(context.Context, command.CreateAppCommand) (string, error) {
+	create := func(existingApps ...*domain.App) func(context.Context, command.CreateAppCommand) (string, error) {
 		store := memory.NewAppsStore(existingApps...)
 		return command.CreateApp(store, store)
 	}
@@ -28,7 +28,9 @@ func Test_CreateApp(t *testing.T) {
 	})
 
 	t.Run("should fail if the name is already taken", func(t *testing.T) {
-		uc := create(domain.NewApp("my-app", "uid"))
+		app := domain.NewApp("my-app", "uid")
+		uc := create(&app)
+
 		_, err := uc(ctx, command.CreateAppCommand{
 			Name: "my-app",
 		})

--- a/internal/deployment/app/command/promote_test.go
+++ b/internal/deployment/app/command/promote_test.go
@@ -16,9 +16,9 @@ import (
 func Test_Promote(t *testing.T) {
 	ctx := auth.WithUserID(context.Background(), "some-uid")
 	app := domain.NewApp("my-app", "some-uid")
-	appsStore := memory.NewAppsStore(app)
+	appsStore := memory.NewAppsStore(&app)
 
-	promote := func(existingDeployments ...domain.Deployment) func(ctx context.Context, cmd command.PromoteCommand) (int, error) {
+	promote := func(existingDeployments ...*domain.Deployment) func(ctx context.Context, cmd command.PromoteCommand) (int, error) {
 		deploymentsStore := memory.NewDeploymentsStore(existingDeployments...)
 		return command.Promote(appsStore, deploymentsStore, deploymentsStore)
 	}
@@ -44,7 +44,7 @@ func Test_Promote(t *testing.T) {
 
 	t.Run("should correctly creates a new deployment based on the provided one", func(t *testing.T) {
 		dpl, _ := app.NewDeployment(1, raw.Data(""), domain.Staging, "some-uid")
-		uc := promote(dpl)
+		uc := promote(&dpl)
 
 		number, err := uc(ctx, command.PromoteCommand{
 			AppID:            string(dpl.ID().AppID()),

--- a/internal/deployment/app/command/queue_deployment_test.go
+++ b/internal/deployment/app/command/queue_deployment_test.go
@@ -17,7 +17,7 @@ import (
 func Test_QueueDeployment(t *testing.T) {
 	ctx := auth.WithUserID(context.Background(), "some-uid")
 	app := domain.NewApp("my-app", "some-uid")
-	appsStore := memory.NewAppsStore(app)
+	appsStore := memory.NewAppsStore(&app)
 
 	queue := func() func(ctx context.Context, cmd command.QueueDeploymentCommand) (int, error) {
 		deploymentsStore := memory.NewDeploymentsStore()

--- a/internal/deployment/app/command/redeploy_test.go
+++ b/internal/deployment/app/command/redeploy_test.go
@@ -16,9 +16,9 @@ import (
 func Test_Redeploy(t *testing.T) {
 	ctx := auth.WithUserID(context.Background(), "some-uid")
 	app := domain.NewApp("my-app", "some-uid")
-	appsStore := memory.NewAppsStore(app)
+	appsStore := memory.NewAppsStore(&app)
 
-	redeploy := func(existingDeployments ...domain.Deployment) func(ctx context.Context, cmd command.RedeployCommand) (int, error) {
+	redeploy := func(existingDeployments ...*domain.Deployment) func(ctx context.Context, cmd command.RedeployCommand) (int, error) {
 		deploymentsStore := memory.NewDeploymentsStore(existingDeployments...)
 		return command.Redeploy(appsStore, deploymentsStore, deploymentsStore)
 	}
@@ -44,7 +44,7 @@ func Test_Redeploy(t *testing.T) {
 
 	t.Run("should correctly creates a new deployment based on the provided one", func(t *testing.T) {
 		dpl, _ := app.NewDeployment(1, raw.Data(""), domain.Production, "some-uid")
-		uc := redeploy(dpl)
+		uc := redeploy(&dpl)
 
 		number, err := uc(ctx, command.RedeployCommand{
 			AppID:            string(dpl.ID().AppID()),

--- a/internal/deployment/app/command/request_app_cleanup_test.go
+++ b/internal/deployment/app/command/request_app_cleanup_test.go
@@ -14,7 +14,7 @@ import (
 
 func Test_RequestAppCleanup(t *testing.T) {
 	ctx := auth.WithUserID(context.Background(), "some-uid")
-	delete := func(existingApps ...domain.App) func(context.Context, command.RequestAppCleanupCommand) error {
+	delete := func(existingApps ...*domain.App) func(context.Context, command.RequestAppCleanupCommand) error {
 		store := memory.NewAppsStore(existingApps...)
 		return command.RequestAppCleanup(store, store)
 	}
@@ -31,12 +31,13 @@ func Test_RequestAppCleanup(t *testing.T) {
 
 	t.Run("should mark an application has ready for deletion", func(t *testing.T) {
 		app := domain.NewApp("my-app", "uid")
-		uc := delete(app)
+		uc := delete(&app)
 
 		err := uc(ctx, command.RequestAppCleanupCommand{
 			ID: string(app.ID()),
 		})
 
 		testutil.IsNil(t, err)
+		testutil.EventIs[domain.AppCleanupRequested](t, &app, 1)
 	})
 }

--- a/internal/deployment/infra/memory/apps.go
+++ b/internal/deployment/infra/memory/apps.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/YuukanOO/seelf/internal/deployment/domain"
 	"github.com/YuukanOO/seelf/pkg/apperr"
-	"github.com/YuukanOO/seelf/pkg/collections"
 	"github.com/YuukanOO/seelf/pkg/event"
 )
 
@@ -26,11 +25,10 @@ type (
 	}
 )
 
-func NewAppsStore(existingApps ...domain.App) AppsStore {
+func NewAppsStore(existingApps ...*domain.App) AppsStore {
 	s := &appsStore{}
-	ctx := context.Background()
 
-	s.Write(ctx, collections.ToPointers(existingApps)...)
+	s.Write(context.Background(), existingApps...)
 
 	return s
 }
@@ -81,6 +79,7 @@ func (s *appsStore) Write(ctx context.Context, apps ...*domain.App) error {
 			case domain.AppDeleted:
 				for i, a := range s.apps {
 					if a.id == app.ID() {
+						*a.value = *app
 						s.apps = append(s.apps[:i], s.apps[i+1:]...)
 						break
 					}
@@ -88,7 +87,7 @@ func (s *appsStore) Write(ctx context.Context, apps ...*domain.App) error {
 			default:
 				for _, a := range s.apps {
 					if a.id == app.ID() {
-						a.value = app
+						*a.value = *app
 						break
 					}
 				}

--- a/internal/worker/app/command/fail_running_jobs_test.go
+++ b/internal/worker/app/command/fail_running_jobs_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func Test_FailRunningJobs(t *testing.T) {
-	sut := func(existingJobs ...domain.Job) (func(context.Context, error) error, memory.JobsStore) {
+	sut := func(existingJobs ...*domain.Job) func(context.Context, error) error {
 		store := memory.NewJobsStore(existingJobs...)
-		return command.FailRunningJobs(store, store), store
+		return command.FailRunningJobs(store, store)
 	}
 
 	t.Run("should reset running jobs", func(t *testing.T) {
@@ -24,14 +24,10 @@ func Test_FailRunningJobs(t *testing.T) {
 		job1 := domain.NewJob(payload{}, monad.None[string]())
 		job2 := domain.NewJob(payload{}, monad.None[string]())
 
-		fail, store := sut(job1, job2)
+		fail := sut(&job1, &job2)
 
 		err := fail(ctx, reason)
 
-		testutil.IsNil(t, err)
-		job1, err = store.GetByID(ctx, job1.ID())
-		testutil.IsNil(t, err)
-		job2, err = store.GetByID(ctx, job2.ID())
 		testutil.IsNil(t, err)
 
 		evt := testutil.EventIs[domain.JobFailed](t, &job1, 1)


### PR DESCRIPTION
It makes it easier to assert modification of an existing record without relying on `GetByID`.