### PR TITLE
Minor fixes after the 2.2.0 release

### DIFF
--- a/cmd/serve/front/src/assets/styles.css
+++ b/cmd/serve/front/src/assets/styles.css
@@ -69,7 +69,8 @@
 	--ra-4: 0.5rem;
 
 	/** Outlines */
-	--ou-primary: var(--co-primary-3) solid 3px;
+	--ou-size: 3px;
+	--ou-primary: var(--co-primary-3) solid var(--ou-size);
 
 	/** Misc. */
 	--mi-container-width: 56rem;

--- a/cmd/serve/front/src/components/service-info.svelte
+++ b/cmd/serve/front/src/components/service-info.svelte
@@ -12,7 +12,7 @@
 		<div class="image-pill">{data.image}</div>
 	</Stack>
 	{#if data.entrypoints && data.entrypoints.length > 0}
-		<Stack as="ul" wrap="wrap" gap={1}>
+		<Stack as="ul" class="entrypoints" wrap="wrap" gap={0}>
 			{#each data.entrypoints as entrypoint (entrypoint.name)}
 				<li class="entrypoint">
 					<EntrypointPill data={entrypoint} />
@@ -30,8 +30,13 @@
 		padding: var(--sp-2);
 	}
 
+	.entrypoints {
+		margin: calc(-1 * var(--ou-size));
+	}
+
 	.entrypoint {
 		overflow: hidden;
+		padding: var(--ou-size);
 	}
 
 	.image-pill {

--- a/internal/deployment/infra/sqlite/migrations/1714119553_add_target_entrypoints.up.sql
+++ b/internal/deployment/infra/sqlite/migrations/1714119553_add_target_entrypoints.up.sql
@@ -1,5 +1,35 @@
 ALTER TABLE targets ADD entrypoints TEXT NOT NULL DEFAULT '{}';
 
+-- Update all targets with a new version to force the reconfiguration since the default http entrypoint name have changed.
+UPDATE targets
+SET
+    state_version = '2024-05-19T00:00:00Z'
+    , state_status = 0;
+
+-- And schedule it
+INSERT INTO scheduled_jobs (
+    id
+    ,resource_id
+    ,[group]
+    ,message_name
+    ,message_data
+    ,queued_at
+    ,not_before
+    ,policy
+    ,retrieved
+)
+SELECT
+    id
+    , id
+    , 'deployment.target.configure.' || id
+    , 'deployment.command.configure_target'
+    , '{"id":"' || id || '","version":"2024-05-19T00:00:00Z"}'
+    , DATETIME()
+    , DATETIME()
+    , 8
+    , false
+FROM targets;
+
 -- When a deployment is marked as failed, remove all pending jobs for that resource.
 -- This is to avoid running jobs that are no longer needed.
 CREATE TRIGGER IF NOT EXISTS on_deployment_failed_cleanup_jobs AFTER UPDATE ON deployments


### PR DESCRIPTION
- Entrypoint outline was hidden
- The migration script does not include a scheduled target configuration needed since the default http entrypoint name have changed. Without it, new deployments without reconfiguring were broken